### PR TITLE
This patch is useful for listing tar contents as a tree.

### DIFF
--- a/tree.py
+++ b/tree.py
@@ -125,6 +125,10 @@ class Tree(object):
 
         line = line.strip()
 
+        # strips trailing '/'
+        if line[-1] == '/':
+          line = line[0:-1]
+
         path = None
         info = {}
 


### PR DESCRIPTION
Code added to strip trailing '/'.
It prevent listing extra entry.

Consider the following input (output of tar -t):

```
dotfiles/
dotfiles/zsh/
dotfiles/tmux/
dotfiles/vim/
```

Original Output:

```
dotfiles
├──
├── tmux
│   └──
├── vim
│   └──
└── zsh
    └──
```

New Output:

```
dotfiles
├── tmux
├── vim
└── zsh
```
